### PR TITLE
feat: use ZeroSSL

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -293,6 +293,11 @@ build-docker-compose: ## Builds docker-compose.yml
 			exit 1; \
 	fi
 	@sed -i.bak 's/<user-rollup-identifier>/$(USER_ROLLUP_IDENTIFIER)/g' docker-compose.yml
+	@if [ -z "$(ZEROSSL_API_KEY)" ]; then \
+			echo "Error: ZEROSSL_API_KEY variable is not set. Please provide a value."; \
+			exit 1; \
+	fi
+	@sed -i.bak 's/<ZEROSSL_API_KEY>/$(ZEROSSL_API_KEY)/g' docker-compose.yml
 	@rm -f docker-compose.yml.bak
 
 .PHONY: run-l2-explorer-json-rpc

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -366,6 +366,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - "DEFAULT_EMAIL=founders@snapchain.dev"
+      - "ACME_CA_URI=https://acme.zerossl.com/v2/DV90"
+      - "ZEROSSL_API_KEY=<ZEROSSL_API_KEY>"
 
   zkevm-explorer-json-rpc:
     container_name: zkevm-explorer-json-rpc


### PR DESCRIPTION
## Summary

letsencrypt has a rate limit. ZeroSSL's paid plan does not

what's really nice is nginx-proxy/acme-companion support it out-of-box!

https://github.com/nginx-proxy/acme-companion/blob/main/docs/Zero-SSL.md

## Test Plan
- `make build-docker-compose USER_ROLLUP_IDENTIFIER=123 ZEROSSL_API_KEY=666`
- test on EC2 and it can download SSL for the sites