### PR TITLE
feat: allow L2 chain ID config

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -335,6 +335,12 @@ build-docker-compose: ## Builds docker-compose.yml
 	fi
 	@sed -i.bak 's/<ZEROSSL_API_KEY>/$(ZEROSSL_API_KEY)/g' docker-compose.yml
 	@rm -f docker-compose.yml.bak
+	@if [ -z "$(L2_CHAIN_ID)" ]; then \
+			echo "Error: L2_CHAIN_ID variable is not set. Please provide a value."; \
+			exit 1; \
+	fi
+	@sed -i.bak 's/<l2-chain-id>/$(L2_CHAIN_ID)/g' config/test.node.config.toml
+	@rm -f config/test.node.config.toml.bak
 
 .PHONY: run-l2-explorer-json-rpc
 run-l2-explorer-json-rpc: ## Runs L2 explorer json rpc

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -33,7 +33,7 @@ PollMinAllowedGasPriceInterval = "15s"
 
 [Etherman]
 URL = "http://zkevm-mock-l1-network:8545"
-L2ChainID = 57489
+L2ChainID = <l2-chain-id>
 MultiGasProvider = false
 	[Etherscan]
 		ApiKey = ""


### PR DESCRIPTION
## Summary
^. modify the make command `build-docker-compose` that will be used in our deployment stack

## Test Plan
`make build-docker-compose USER_ROLLUP_IDENTIFIER=ac ZEROSSL_API_KEY=asdasd L2_CHAIN_ID=12333`